### PR TITLE
[llvm-dis] Update header comment to reflect current command-line options

### DIFF
--- a/llvm/tools/llvm-dis/llvm-dis.cpp
+++ b/llvm/tools/llvm-dis/llvm-dis.cpp
@@ -12,6 +12,16 @@
 //                            to the x.ll file.
 //  Options:
 //      --help   - Output information about command line switches
+//      -o <filename>              - Override output filename
+//      -f                         - Enable binary output on terminals
+//      --disable-output           - Don't output the .ll file
+//      --set-importing            - Set lazy loading to pretend to import a module
+//      --show-annotations         - Add informational comments to the .ll file
+//      --preserve-ll-uselistorder - Preserve use-list order when writing LLVM assembly
+//      --materialize-metadata     - Load module without materializing metadata, then
+//                                   materialize only the metadata
+//      --print-thinlto-index-only - Only read thinlto index and print the index as
+//                                   LLVM assembly.
 //
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
Summary:
This PR updates the header comment in `llvm-dis.cpp` to accurately reflect the current command-line options and positional arguments supported by `llvm-dis`. The original comment was outdated and only mentioned the `--help` option, whereas several additional options have been introduced.

Changes Made:
- Updated the comment block to include all relevant options:
  - Short options: `-o`, `-f`.
  - Long options: `--disable-output`, `--set-importing`, `--show-annotations`, `--preserve-ll-uselistorder`, `--materialize-metadata`, `--print-thinlto-index-only`.
- Ensured that hidden options were not included in the header, as per LLVM's guidelines.
  
Testing:
This change only affects comments in the source code and does not impact the functionality of the tool itself. The tool has been tested to verify that no functionality is affected by this update.

Issue Reference:
This PR resolves issue #108069.
